### PR TITLE
added descriptions to liks for the recipies and removed styling rule …

### DIFF
--- a/mistakes.html
+++ b/mistakes.html
@@ -5,11 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script src="https://cdn.tailwindcss.com"></script>
     <title>Learn about desserts</title>
-    <style>
-      a:focus {
-        outline: none;
-      }
-    </style>
   </head>
   <body
     class="bg-repeat object-contain bg-opacity-20 bg-[url('https://ideasparalaclase.com/wp-content/uploads/2017/08/Black-and-white-Polka-Dot-Seamless-Pattern-Paint-Stain-Abstract-600x600.jpeg')]"
@@ -175,7 +170,7 @@
               <a
                 class="underline text-fuchsia-800 hover:no-underline text-right mt-4"
                 href="https://www.pbs.org/food/recipes/cookie-monster-cupcakes/"
-                >Recipe</a
+                >Cookie monster cupcake recipe</a
               >
             </div>
           </li>
@@ -190,7 +185,7 @@
               <a
                 class="underline text-fuchsia-800 hover:no-underline text-right mt-4"
                 href="https://www.yummly.com/recipe/The-BEST-Chocolate-Chip-Cookies-2639812?prm-v1"
-                >Recipe</a
+                >Chocolate chip cookie recipe</a
               >
             </div>
           </li>
@@ -205,7 +200,7 @@
               <a
                 class="underline text-fuchsia-800 hover:no-underline text-right mt-4"
                 href="https://www.notonthehighstreet.com/honeywellbakes/product/teddy-bear-bun-baking-kit?referredBy=search"
-                >Recipe</a
+                >Pull-apart sweet buns recipe</a
               >
             </div>
           </li>


### PR DESCRIPTION
Issue 1 : Links with no description (Links with ambiguous text)

**how the error was found**: when analyzing the website I noticed that the cards with dessert disasters have links at the bottom. The problem was that those links didn't have any description where they are connected to, there was only the word "Recipe", which is not descriptive at all. The user would not know what page is linked there.
**resources used:** [WCAG SC2.4.4](https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context), [WCAG Technique F63](https://www.w3.org/WAI/WCAG21/Techniques/failures/F63)
**what I learned:** how important it is to describe to the user where the link will take them.

Issue 2 : No focus outlines

**how the error was found**: when navigating through the website with tab I noticed that I was taken to different section of the site, but the focused one was not outlined, therefore I didin't know what part is active.
**resources used:** [WCAG SC2.4.7](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible), [WCAG Technique F78](https://www.w3.org/WAI/WCAG21/Techniques/failures/F78)
**what I learned:** to always make sure that the focus outline is enabled.
