### PR TITLE
Add lang tag to html element

### DIFF
--- a/mistakes.html
+++ b/mistakes.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
In order to fix this mistake, I added a lang tag to the html tag. I located the html tag at the top of the page and added "lang="en" within it.

The language of a page section from WCAG was the most helpful. I learned that the text is not automatically loaded into a language to then be utilized by a text reader so we need to add the language tag so the text reader can use the correction pronunciation of words and phrases. 