### PR TITLE
Fixing errors for issue types 5, 6, and 7

### DIFF
--- a/mistakes.html
+++ b/mistakes.html
@@ -108,13 +108,13 @@
           In order from most popular to least popular, CherryOnTech did a poll
           and found that the following cakes were the most popular:
         </p>
-        <div class="flex flex-col my-4">
-          <p>1. Chocolate</p>
-          <p>2. Red velvet</p>
-          <p>3. Banana</p>
-          <p>4. Vanilla</p>
-          <p>5. Pistachio</p>
-        </div>
+        <ol class="flex flex-col my-4">
+          <li>Chocolate</li>
+          <li>Red velvet</li>
+          <li>Banana</li>
+          <li>Vanilla</li>
+          <li>Pistachio</li>
+        </ol>
 
         <h3 class="text-2xl mb-4 mt-6 border-b-2 border-pink-200">Cookies</h3>
         <p>

--- a/mistakes.html
+++ b/mistakes.html
@@ -108,7 +108,7 @@
           In order from most popular to least popular, CherryOnTech did a poll
           and found that the following cakes were the most popular:
         </p>
-        <ol class="flex flex-col my-4">
+        <ol class="list-decimal list-inside">
           <li>Chocolate</li>
           <li>Red velvet</li>
           <li>Banana</li>

--- a/mistakes.html
+++ b/mistakes.html
@@ -18,7 +18,7 @@
       class="bg-opacity-95 min-h-1/3 bg-blue-100 flex flex-col justify-evenly items-center flex-col-reverse md:flex-row p-6 gap-6 md:gap-12"
     >
       <div class="flex flex-col gap-4 md:ml-6">
-        <p class="text-6xl md:text-left text-center">What's for dessert?</p>
+        <h1 class="text-6xl md:text-left text-center">What's for dessert?</h1>
         <p class="italic text-slate-400">
           This page has several mistakes which could impact both its
           accessibility and usability! Check out the README in the
@@ -130,7 +130,7 @@
           these popular grocery outlets:
         </p>
 
-         <ul class="list-disc list-inside">
+        <ul class="list-disc list-inside">
           <li>
             <a
               class="underline text-fuchsia-800 hover:no-underline"

--- a/mistakes.html
+++ b/mistakes.html
@@ -7,7 +7,7 @@
     <title>Learn about desserts</title>
     <style>
       a:focus {
-        outline: none;
+        outline: 2px solid blue;
       }
     </style>
   </head>


### PR DESCRIPTION
### Issue type 5: Focus outlines
To find this error, I opened up `mistakes.html` in my web browser and then tried to use tab to navigate through the site. I noticed the focus outline was missing, and after referencing [WCAG Technique F78](https://www.w3.org/WAI/WCAG21/Techniques/failures/F78) I found that `:focus {outline: none}` was in the file. I updated it to match the styling on the "known good" page.

### Issue type 6: A series of elements which should be a list
I found this error by looking over the `mistakes.html` file in my code editor on one screen and having it open in my web browser on another screen. When I found an element that was styled as a list I then found the corresponding lines in the HTML file and checked to see whether the code matched the appearance. I referenced [WCAG Technique H48](https://www.w3.org/WAI/WCAG21/Techniques/html/H48) to see how to fix the issue, and updated the code from using `<p>` elements inside a `<div>` to using `<li>` elements inside an `<ol>`.

### Issue type 7: An element styled to look like a heading, but isn't
I used a similar method to look for errors for this issue type as I did for issue type 6; the only difference was I was checking headers instead of lists. I referenced [WCAG Technique H42](https://www.w3.org/WAI/WCAG21/Techniques/html/H42) to see how to fix the issue. I added the missing `<h1>` tag and then checked the remaining header tags to make sure that they correctly reflected the hierarchical relationship between each of the sections.